### PR TITLE
[Fix] Return after redirect

### DIFF
--- a/javascript/index.html
+++ b/javascript/index.html
@@ -32,6 +32,7 @@
             // Redirect to auth route if token is not retrieved
             if (token == null) {
                 window.location.href = "/auth";
+                return;
             }
 
             let sessionHTML = document.getElementById("session");


### PR DESCRIPTION
Without this return, the JS code below will still run.

eg. it still tries to call ${API_URL}/session/  and you see the error from that show on the page under Session data before the redirect has completed